### PR TITLE
Fix kerberos keytab bug fix

### DIFF
--- a/cm_cdp_cdh_log4j_jndi_removal.sh
+++ b/cm_cdp_cdh_log4j_jndi_removal.sh
@@ -185,7 +185,7 @@ function delete_jndi_from_hdfs {
 
   user_option=""
   keytab_file="hdfs.keytab"
-  keytab=$(find /var/run/cloudera-scm-agent/process/ -type f -iname $keytab_file | grep -e NAMENODE -e DATANODE | tail -1)
+  keytab=$(find /var/run/cloudera-scm-agent/process/ -type f -iname $keytab_file | grep -e NAMENODE -e DATANODE -e JOURNALNODE | tail -1)
   if [[ -z "$keytab" || ! -s $keytab ]]; then
     echo "Keytab file is not found or is empty: $keytab_file. Considering this as a non-secure cluster deployment."
     issecure="false"


### PR DESCRIPTION
Hi.

There is a bug while running the script, so we report it.

We own 5 masternodes.

And Namenode is operating 3 units. Therefore, when executing the following command on the remaining two masters,
keytab=$(find /var/run/cloudera-scm-agent/process/ -type f -iname $keytab_file | grep -e NAMENODE -e DATANODE | tail -1)

That could be a problem.

That pr is not a fundamental solution. However, it seems that these aspects need to be considered.