### PR TITLE
CDP : Correction for find tar.gz files not working if targetdir is a link

### DIFF
--- a/cm_cdp_cdh_log4j_jndi_removal.sh
+++ b/cm_cdp_cdh_log4j_jndi_removal.sh
@@ -333,7 +333,7 @@ fi
 
 if [ -z "$SKIP_TGZ" ]; then
   echo "Removing JNDI from tar.gz files"
-  for targzfile in $(find $targetdir -name '*.tar.gz') ; do
+  for targzfile in $(find "${targetdir}/" -type f -name '*.tar.gz') ; do
     delete_jndi_from_targz_file $targzfile $backupdir
   done
 else


### PR DESCRIPTION
Hi
If default targetdir (/opt/cloudera) is a link the find for .tar.gz files does not work and does not patch any .tar.gz file on the hosts.

In the vulnerability scan you dont use the same method (using globstar) and you find the tar.gz files not patched with the vulnerability.

So if you do the patch and after the scan you will see that the patch doesn't find the tar.gz files and doesn't patch it.

So I add a / at the end of targetdir for find to work.

Eric.
Regards
