### PR TITLE
add unzip overwrite param

### DIFF
--- a/cm_cdp_cdh_log4j_jndi_removal.sh
+++ b/cm_cdp_cdh_log4j_jndi_removal.sh
@@ -31,7 +31,7 @@ function scan_for_jndi {
   for warfile in $targetdir/**/*.{war,nar}; do
     rm -r -f /tmp/unzip_target
     mkdir /tmp/unzip_target
-    unzip -qq $warfile -d /tmp/unzip_target
+    unzip -o -qq $warfile -d /tmp/unzip_target
 
     found=0  # not found
     for f in $(grep -r -l $pattern /tmp/unzip_target); do
@@ -95,7 +95,7 @@ function delete_jndi_from_jar_files {
 
     rm -r -f /tmp/unzip_target
     mkdir /tmp/unzip_target
-    unzip -qq $narfile -d /tmp/unzip_target
+    unzip -o -qq $narfile -d /tmp/unzip_target
     for jarfile in /tmp/unzip_target/**/*.jar; do
       if grep -q JndiLookup.class $jarfile; then
         # Backup file only if backup doesn't already exist

--- a/hdp_support_scripts/delete_jndi.sh
+++ b/hdp_support_scripts/delete_jndi.sh
@@ -57,7 +57,7 @@ do
     rm -r -f /tmp/unzip_target
 	mkdir /tmp/unzip_target
 	set +e
-	unzip -qq $warfile -d /tmp/unzip_target
+	unzip -o -qq $warfile -d /tmp/unzip_target
 	set -e
 	  for jarfile in /tmp/unzip_target/**/*.jar; do
 		if grep -q JndiLookup.class $jarfile; then

--- a/hdp_support_scripts/scan_jndi.sh
+++ b/hdp_support_scripts/scan_jndi.sh
@@ -45,7 +45,7 @@ do
         rm -r -f /tmp/unzip_target
 	mkdir /tmp/unzip_target
 	set +e
-	unzip -qq $warfile -d /tmp/unzip_target
+	unzip -o -qq $warfile -d /tmp/unzip_target
 	set -e
 	
     found=0  # not found


### PR DESCRIPTION
Fixes #36 

Issue: If a war file contains the same file twice the script will hang when it asks for a response from the user. This becomes an issue especially when running via Ansible or other automation. This fix overwrites the files and avoids prompting the user.